### PR TITLE
fix: resolve lint errors

### DIFF
--- a/src/components/Hero.tsx
+++ b/src/components/Hero.tsx
@@ -14,10 +14,10 @@ const Hero = () => {
     window.open('https://wa.me/5563992476987', '_blank');
   };
   return <section className="min-h-screen flex items-center justify-center relative overflow-hidden">
-      <div className="absolute inset-0 bg-gradient-dark opacity-90" />
+      <div className="absolute inset-0 bg-gradient-dark opacity-90" aria-hidden="true" />
       <div className="absolute inset-0 bg-cover bg-center bg-no-repeat" style={{
       backgroundImage: `url(${heroImage})`
-    }} />
+    }} role="img" aria-label="Imagem de fundo de um desenvolvedor trabalhando em frente ao computador" />
       
       <div className="container mx-auto px-6 relative z-10">
         <div className="max-w-4xl mx-auto text-center animate-fade-in">
@@ -73,5 +73,6 @@ const Hero = () => {
         </div>
       </div>
     </section>;
-};
-export default Hero;
+  };
+
+  export default Hero;

--- a/src/components/ui/command.tsx
+++ b/src/components/ui/command.tsx
@@ -21,7 +21,7 @@ const Command = React.forwardRef<
 ))
 Command.displayName = CommandPrimitive.displayName
 
-interface CommandDialogProps extends DialogProps {}
+type CommandDialogProps = DialogProps
 
 const CommandDialog = ({ children, ...props }: CommandDialogProps) => {
   return (

--- a/src/components/ui/textarea.tsx
+++ b/src/components/ui/textarea.tsx
@@ -2,8 +2,7 @@ import * as React from "react"
 
 import { cn } from "@/lib/utils"
 
-export interface TextareaProps
-  extends React.TextareaHTMLAttributes<HTMLTextAreaElement> {}
+export type TextareaProps = React.TextareaHTMLAttributes<HTMLTextAreaElement>
 
 const Textarea = React.forwardRef<HTMLTextAreaElement, TextareaProps>(
   ({ className, ...props }, ref) => {

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -1,4 +1,5 @@
 import type { Config } from "tailwindcss";
+import tailwindcssAnimate from "tailwindcss-animate";
 
 export default {
 	darkMode: ["class"],
@@ -133,5 +134,5 @@ export default {
 			}
 		}
 	},
-	plugins: [require("tailwindcss-animate")],
+        plugins: [tailwindcssAnimate],
 } satisfies Config;


### PR DESCRIPTION
## Summary
- replace empty interfaces with type aliases in command and textarea components
- switch Tailwind config to ESM plugin import

## Testing
- `npm run lint`
- `npm run build`
- `npm test` *(fails: Missing script "test")*
- `npx lighthouse http://localhost:4173 --quiet --only-categories=accessibility --chrome-flags="--headless"` *(fails: 403 Forbidden - registry access)*

------
https://chatgpt.com/codex/tasks/task_e_68b5dd4c87ec832abc146a70a8a4a92e